### PR TITLE
Add onEnter and onExit events to states

### DIFF
--- a/Swift/Sources/StateMachine/StateMachine.swift
+++ b/Swift/Sources/StateMachine/StateMachine.swift
@@ -13,15 +13,13 @@ open class StateMachine<State: StateMachineHashable, Event: StateMachineHashable
         public struct Valid: CustomDebugStringConvertible {
 
             public var debugDescription: String {
-                guard let sideEffect: SideEffect = sideEffect
-                else { return "fromState: \(fromState), event: \(event), toState: \(toState), sideEffect: nil" }
-                return "fromState: \(fromState), event: \(event), toState: \(toState), sideEffect: \(sideEffect)"
+                return "fromState: \(fromState), event: \(event), toState: \(toState), sideEffect: \(sideEffects)"
             }
 
             public let fromState: State
             public let event: Event
             public let toState: State
-            public let sideEffect: SideEffect?
+            public let sideEffects: [SideEffect]
         }
 
         public struct Invalid: Error, Equatable {}
@@ -105,7 +103,7 @@ open class StateMachine<State: StateMachineHashable, Event: StateMachineHashable
                 let transition: Transition.Valid = .init(fromState: state,
                                                          event: event,
                                                          toState: action.toState ?? state,
-                                                         sideEffect: action.sideEffect)
+                                                         sideEffects: action.sideEffects)
                 if let toState: State = action.toState {
                     state = toState
                 }
@@ -197,15 +195,15 @@ extension StateMachineBuilder {
 
     public static func transition(
         to state: State,
-        emit sideEffect: SideEffect? = nil
+        emit sideEffect: SideEffect...
     ) -> Action {
-        Action(toState: state, sideEffect: sideEffect)
+        Action(toState: state, sideEffects: sideEffect)
     }
 
     public static func dontTransition(
-        emit sideEffect: SideEffect? = nil
+        emit sideEffect: SideEffect...
     ) -> Action {
-        Action(toState: nil, sideEffect: sideEffect)
+        Action(toState: nil, sideEffects: sideEffect)
     }
 
     public static func onTransition(
@@ -288,7 +286,7 @@ public enum StateMachineTypes {
         fileprivate typealias Factory = (State, Event) throws -> Self
 
         fileprivate let toState: State?
-        fileprivate let sideEffect: SideEffect?
+        fileprivate let sideEffects: [SideEffect]
     }
 
     public struct IncorrectTypeError: Error, CustomDebugStringConvertible {

--- a/Swift/Sources/StateMachine/StateMachine.swift
+++ b/Swift/Sources/StateMachine/StateMachine.swift
@@ -13,7 +13,7 @@ open class StateMachine<State: StateMachineHashable, Event: StateMachineHashable
         public struct Valid: CustomDebugStringConvertible {
 
             public var debugDescription: String {
-                return "fromState: \(fromState), event: \(event), toState: \(toState), sideEffect: \(sideEffects)"
+                return "fromState: \(fromState), event: \(event), toState: \(toState), sideEffects: \(sideEffects)"
             }
 
             public let fromState: State

--- a/Swift/Tests/StateMachineTests/StateMachineTests.swift
+++ b/Swift/Tests/StateMachineTests/StateMachineTests.swift
@@ -224,3 +224,13 @@ func log(_ expectedMessages: String...) -> Predicate<Logger> {
         return PredicateResult(bool: actualMessages == expectedMessages, message: message)
     }
 }
+
+func noLog() -> Predicate<Logger> {
+    return Predicate {
+        let actualMessages: [String]? = try $0.evaluate()?.messages
+        let actualString: String = stringify(actualMessages?.joined(separator: "\\n"))
+        let message: ExpectationMessage = .expectedCustomValueTo("no logs",
+                                                                 actual: "<\(actualString)>")
+        return PredicateResult(bool: actualString.count == 0, message: message)
+    }
+}

--- a/Swift/Tests/StateMachineTests/StateMachineTests.swift
+++ b/Swift/Tests/StateMachineTests/StateMachineTests.swift
@@ -66,7 +66,7 @@ final class StateMachineTests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .stateOne,
                                                     event: .eventOne,
                                                     toState: .stateOne,
-                                                    sideEffect: .commandOne)))
+                                                    sideEffects: [.commandOne])))
     }
 
     func testTransition() throws {
@@ -82,7 +82,7 @@ final class StateMachineTests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .stateOne,
                                                     event: .eventTwo,
                                                     toState: .stateTwo,
-                                                    sideEffect: .commandTwo)))
+                                                    sideEffects: [.commandTwo])))
     }
 
     func testInvalidTransition() throws {
@@ -131,16 +131,16 @@ final class StateMachineTests: XCTestCase, StateMachineBuilder {
             .success(ValidTransition(fromState: .stateOne,
                                      event: .eventOne,
                                      toState: .stateOne,
-                                     sideEffect: .commandOne)),
+                                     sideEffects: [.commandOne])),
             .success(ValidTransition(fromState: .stateOne,
                                      event: .eventTwo,
                                      toState: .stateTwo,
-                                     sideEffect: .commandTwo)),
+                                     sideEffects: [.commandTwo])),
             .failure(InvalidTransition()),
             .success(ValidTransition(fromState: .stateTwo,
                                      event: .eventTwo,
                                      toState: .stateTwo,
-                                     sideEffect: .commandThree))
+                                     sideEffects: [.commandThree]))
         ]))
     }
 

--- a/Swift/Tests/StateMachineTests/StateMachine_Matter_Tests.swift
+++ b/Swift/Tests/StateMachineTests/StateMachine_Matter_Tests.swift
@@ -58,12 +58,14 @@ final class StateMachine_Matter_Tests: XCTestCase, StateMachineBuilder {
                 }
             }
             onTransition {
-                guard case let .success(transition) = $0, let sideEffect = transition.sideEffect else { return }
-                switch sideEffect {
-                case .logMelted: logger.log(Message.melted)
-                case .logFrozen: logger.log(Message.frozen)
-                case .logVaporized: logger.log(Message.vaporized)
-                case .logCondensed: logger.log(Message.condensed)
+                guard case let .success(transition) = $0 else { return }
+                transition.sideEffects.forEach { sideEffect in
+                    switch sideEffect {
+                    case .logMelted: logger.log(Message.melted)
+                    case .logFrozen: logger.log(Message.frozen)
+                    case .logVaporized: logger.log(Message.vaporized)
+                    case .logCondensed: logger.log(Message.condensed)
+                    }
                 }
             }
         }
@@ -100,7 +102,7 @@ final class StateMachine_Matter_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .solid,
                                                     event: .melt,
                                                     toState: .liquid,
-                                                    sideEffect: .logMelted)))
+                                                    sideEffects: [.logMelted])))
         expect(self.logger).to(log(Message.melted))
     }
 
@@ -133,7 +135,7 @@ final class StateMachine_Matter_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .liquid,
                                                     event: .freeze,
                                                     toState: .solid,
-                                                    sideEffect: .logFrozen)))
+                                                    sideEffects: [.logFrozen])))
         expect(self.logger).to(log(Message.frozen))
     }
 
@@ -150,7 +152,7 @@ final class StateMachine_Matter_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .liquid,
                                                     event: .vaporize,
                                                     toState: .gas,
-                                                    sideEffect: .logVaporized)))
+                                                    sideEffects: [.logVaporized])))
         expect(self.logger).to(log(Message.vaporized))
     }
 
@@ -167,7 +169,7 @@ final class StateMachine_Matter_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .gas,
                                                     event: .condense,
                                                     toState: .liquid,
-                                                    sideEffect: .logCondensed)))
+                                                    sideEffects: [.logCondensed])))
         expect(self.logger).to(log(Message.condensed))
     }
 }

--- a/Swift/Tests/StateMachineTests/StateMachine_Turnstile_Tests.swift
+++ b/Swift/Tests/StateMachineTests/StateMachine_Turnstile_Tests.swift
@@ -95,7 +95,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .locked(credit: 0),
                                                     event: .insertCoin(10),
                                                     toState: .locked(credit: 10),
-                                                    sideEffect: nil)))
+                                                    sideEffects: [])))
     }
 
     func test_givenStateIsLocked_whenInsertCoin_andCreditEqualsFarePrice_shouldTransitionToUnlockedStateAndOpenDoors() throws {
@@ -111,7 +111,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .locked(credit: 35),
                                                     event: .insertCoin(15),
                                                     toState: .unlocked,
-                                                    sideEffect: .openDoors)))
+                                                    sideEffects: [.openDoors])))
     }
 
     func test_givenStateIsLocked_whenInsertCoin_andCreditMoreThanFarePrice_shouldTransitionToUnlockedStateAndOpenDoors() throws {
@@ -127,7 +127,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .locked(credit: 35),
                                                     event: .insertCoin(20),
                                                     toState: .unlocked,
-                                                    sideEffect: .openDoors)))
+                                                    sideEffects: [.openDoors])))
     }
 
     func test_givenStateIsLocked_whenAdmitPerson_shouldTransitionToLockedStateAndSoundAlarm() throws {
@@ -143,7 +143,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .locked(credit: 35),
                                                     event: .admitPerson,
                                                     toState: .locked(credit: 35),
-                                                    sideEffect: .soundAlarm)))
+                                                    sideEffects: [.soundAlarm])))
     }
 
     func test_givenStateIsLocked_whenMachineDidFail_shouldTransitionToBrokenStateAndOrderRepair() throws {
@@ -159,7 +159,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .locked(credit: 15),
                                                     event: .machineDidFail,
                                                     toState: .broken(oldState: .locked(credit: 15)),
-                                                    sideEffect: .orderRepair)))
+                                                    sideEffects: [.orderRepair])))
     }
 
     func test_givenStateIsUnlocked_whenAdmitPerson_shouldTransitionToLockedStateAndCloseDoors() throws {
@@ -175,7 +175,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .unlocked,
                                                     event: .admitPerson,
                                                     toState: .locked(credit: 0),
-                                                    sideEffect: .closeDoors)))
+                                                    sideEffects: [.closeDoors])))
     }
 
     func test_givenStateIsBroken_whenMachineRepairDidComplete_shouldTransitionToLockedState() throws {
@@ -191,7 +191,7 @@ final class StateMachine_Turnstile_Tests: XCTestCase, StateMachineBuilder {
         expect(transition).to(equal(ValidTransition(fromState: .broken(oldState: .locked(credit: 15)),
                                                     event: .machineRepairDidComplete,
                                                     toState: .locked(credit: 15),
-                                                    sideEffect: nil)))
+                                                    sideEffects: [])))
     }
 }
 


### PR DESCRIPTION
Those event are present in an android version of the state machine and are missed in iOS version, so it is not possible to use the same logic between platforms.